### PR TITLE
Fix paths to be OS neutral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ target/
 
 # Backup files
 *~
+*.hdf5

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include python/bolo/PKL/*.pkl

--- a/python/bolo/data_utils.py
+++ b/python/bolo/data_utils.py
@@ -170,7 +170,7 @@ class TableDict:
         extype = os.path.splitext(filepath)[1]
         if extype in HDF5_SUFFIXS:
             for key, val in self._table_dict.items():
-                val.write(filepath, path=key, **kwargs)
+                val.write(filepath, path=key, overwrite=True, **kwargs)
         elif extype in FITS_SUFFIXS:
             if self._primary is None:
                 hlist = [fits.PrimaryHDU()]

--- a/python/bolo/instrument.py
+++ b/python/bolo/instrument.py
@@ -90,7 +90,7 @@ class Instrument(Model):
     def write_tables(self, filename):
         """ Write output fits tables """
         if self._tables:
-            self._tables.save_datatables(filename, overwrite=True)
+            self._tables.save_datatables(filename)
 
     @property
     def tables(self):

--- a/python/bolo/instrument.py
+++ b/python/bolo/instrument.py
@@ -90,7 +90,7 @@ class Instrument(Model):
     def write_tables(self, filename):
         """ Write output fits tables """
         if self._tables:
-            self._tables.save_datatables(filename)
+            self._tables.save_datatables(filename, overwrite=True)
 
     @property
     def tables(self):

--- a/python/bolo/noise.py
+++ b/python/bolo/noise.py
@@ -153,17 +153,17 @@ class Noise: #pylint: disable=too-many-instance-attributes
         # Correlation files
         corr_dir = os.path.join(
             os.path.split(__file__)[0], "PKL")
-        self._p_c_apert, self._c_apert = pk.load(io.open(
-            os.path.join(corr_dir, "coherentApertCorr.pkl"), "rb"),
+        self._p_c_apert, self._c_apert = pk.load(io.open(os.path.normpath(
+            os.path.join(corr_dir, "coherentApertCorr.pkl")), "rb"),
                             encoding="latin1")
-        self._p_c_stop,  self._c_stop = pk.load(io.open(
-            os.path.join(corr_dir, "coherentStopCorr.pkl"), "rb"),
+        self._p_c_stop,  self._c_stop = pk.load(io.open(os.path.normpath(
+            os.path.join(corr_dir, "coherentStopCorr.pkl")), "rb"),
                             encoding="latin1")
-        self._p_i_apert, self._i_apert = pk.load(io.open(
-            os.path.join(corr_dir, "incoherentApertCorr.pkl"), "rb"),
+        self._p_i_apert, self._i_apert = pk.load(io.open(os.path.normpath(
+            os.path.join(corr_dir, "incoherentApertCorr.pkl")), "rb"),
                             encoding="latin1")
-        self._p_i_stop,  self._i_stop = pk.load(io.open(
-            os.path.join(corr_dir, "incoherentStopCorr.pkl"), "rb"),
+        self._p_i_stop,  self._i_stop = pk.load(io.open(os.path.normpath(
+            os.path.join(corr_dir, "incoherentStopCorr.pkl")), "rb"),
                             encoding="latin1")
 
         # Detector pitch array

--- a/python/bolo/top.py
+++ b/python/bolo/top.py
@@ -1,5 +1,5 @@
 """Top level configuration"""
-
+import os.path
 
 from cfgmdl import Property, Model
 from .sky import Universe

--- a/python/bolo/top.py
+++ b/python/bolo/top.py
@@ -14,7 +14,7 @@ class SimConfig(Model):
     save_sim = Property(dtype=bool, default=True)
     save_optical = Property(dtype=bool, default=True)
     freq_resol = Property(dtype=float, default=None)
-    config_dir = Property(dtype=str, default="../config")
+    config_dir = Property(dtype=str, default=os.path.join(os.path.pardir, "config"))
 
     def __init__(self, **kwargs):
         """ Constructor """

--- a/python/bolo/utils.py
+++ b/python/bolo/utils.py
@@ -32,7 +32,7 @@ class CfgDir:
 
     def cfg_path(self, val):
         """ Build a path using the top-level configuration directory """
-        return os.path.join(self.config_dir, val)
+        return os.path.normpath(os.path.join(self.config_dir, val))
 
 CFG_DIR = CfgDir()
 

--- a/python/bolo/utils.py
+++ b/python/bolo/utils.py
@@ -163,7 +163,7 @@ def read_txt_to_np(fname):
         delim = ','
     else:
         raise ValueError("File %s is not csv or txt")
-    return np.loadtxt(fname, unpack=True, dtype=np.float, delimiter=delim)
+    return np.loadtxt(os.path.normpath(fname), unpack=True, dtype=np.float, delimiter=delim)
 
 
 def reshape_array(val, shape):

--- a/scripts/update_atm.py
+++ b/scripts/update_atm.py
@@ -31,7 +31,7 @@ def reporthook(count, block_size, total_size):
 def main():
     # Download atmosphere files
     fname = "atm_20201217.hdf5"
-    top_dir = os.path.abspath(os.path.dirname(__file__)).replace('/scripts', '')
+    top_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
     atm_file = os.path.join(top_dir, "scripts", fname)
     new_atm_file = os.path.join(top_dir, "config", fname)
 
@@ -40,12 +40,12 @@ def main():
     if os.path.exists(atm_file):
         sys.stdout.write("\nSuccessfully downloaded atmosphere file %s." % (fname))
         sys.stdout.write(
-            ("\nADVICE: delete any old atm files (~1 GB each) from BoloCalc" + 
+            ("\nADVICE: delete any old atm files (~1 GB each) from BoloCalc" +
             os.sep + "src" + os.sep + "\n\n"))
         os.rename(atm_file, new_atm_file)
     else:
         sys.stdout.write("\nERROR: problem downloading atmosphere file %s\n\n" % (fname))
 
-        
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I've fixed a few lines in data_utils.py, top.py and update_atm.py so that all the examples and tests now run correctly under Anaconda on Windows and Linux.

Tested on Windows 10 and Rocky Linux 8.5.